### PR TITLE
Fix issues in runAppInBackground method

### DIFF
--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -105,7 +105,7 @@ androidCommon.background = function (secs, cb) {
   this.adb.getFocusedPackageAndActivity(function (err, pack, activity) {
     if (err) return cb(err);
 
-    this.adb.keyevent("3", function (err) {
+    this.adb.keyevent("3", false, function (err) {
       if (err) return cb(err);
 
       setTimeout(function () {


### PR DESCRIPTION
Without this parameter failed with Cannot read property 'maxBuffer' of undefined
